### PR TITLE
Fix typecheck failing on a fresh checkout (missing next-env.d.ts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "oxlint",
+    "pretypecheck": "node scripts/ensure-next-env.js",
     "typecheck": "tsgo --noEmit",
-    "check": "oxlint && tsgo --noEmit"
+    "check": "oxlint && npm run typecheck"
   },
   "engines": {
     "node": "22.17.1"

--- a/scripts/ensure-next-env.js
+++ b/scripts/ensure-next-env.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Ensures `next-env.d.ts` exists before the typecheck gate runs.
+ *
+ * `next-env.d.ts` is gitignored and, per standard Next.js convention, is
+ * normally generated as a side effect of `next dev` / `next build`. That
+ * file is what pulls in `next/image-types/global`, which declares
+ * `*.png` / `*.jpeg` (etc.) imports as valid modules. On a fresh checkout
+ * (`npm ci` followed directly by `npm run typecheck`, with no prior
+ * `next dev`/`next build`), the file doesn't exist yet, so `tsgo --noEmit`
+ * fails with TS2307 on any image import.
+ *
+ * Next 14 has no lighter-weight public CLI command that only writes this
+ * file (that landed later, as `next typegen`), so this script writes the
+ * same content Next itself would generate for this project (app router
+ * only, no pages dir, static image imports enabled - see
+ * next.config.js/next/dist/lib/typescript/writeAppTypeDeclarations.js).
+ *
+ * If the file already exists (e.g. a real `next dev`/`next build` already
+ * ran), it's left untouched.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const target = path.join(__dirname, '..', 'next-env.d.ts');
+
+if (fs.existsSync(target)) {
+	process.exit(0);
+}
+
+const content = [
+	'/// <reference types="next" />',
+	'/// <reference types="next/image-types/global" />',
+	'',
+	'// NOTE: This file should not be edited',
+	'// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.'
+].join('\n') + '\n';
+
+fs.writeFileSync(target, content);


### PR DESCRIPTION
Closes #8

## What
On a fresh checkout, `npm ci` followed directly by `npm run typecheck` (no prior `next dev`/`next build`) failed with TS2307 on image imports in `app/dissect/page.tsx` and `utils/info.tsx`. Root cause: `tsconfig.json`'s `include` list references `next-env.d.ts`, which is gitignored and normally only written as a side effect of `next dev`/`next build`. That file is what pulls in the `next/image-types/global` triple-slash reference, which declares `*.png`/`*.jpeg` imports as valid modules.

Next 14.2.35 (this repo's version) has no public, lighter-weight CLI command that generates just this file — `next typegen` for that purpose only landed in later Next versions (checked `node_modules/.bin/next --help`: only `build`, `dev`, `info`, `lint`, `start`, `telemetry` exist). So instead of depending on Next's private/internal APIs at runtime, this adds:

- `scripts/ensure-next-env.js` — a small, dependency-free script that writes `next-env.d.ts` with the exact content Next's own internal generator (`next/dist/lib/typescript/writeAppTypeDeclarations.js`) would produce for this project (app router only, no `pages` dir, static image imports enabled per `next.config.js`). If the file already exists (e.g. `next dev` already ran), it's left untouched.
- `package.json` — added a `pretypecheck` script (`node scripts/ensure-next-env.js`) so npm's standard pre-script hook runs it automatically before `typecheck`. Also changed `check` to call `npm run typecheck` instead of invoking `tsgo` directly, so it picks up the same hook.

`tsconfig.json` did not need changes — once `next-env.d.ts` is guaranteed to exist before `tsgo` runs, its existing `include` entry resolves correctly.

## Verification
Content match against Next's actual internal generator, run on this branch:
```
$ node -e "
const { writeAppTypeDeclarations } = require('./node_modules/next/dist/lib/typescript/writeAppTypeDeclarations');
... writes to /tmp/next-env.d.ts and compares to our script's output ...
"
MATCH: true
```

Fresh-checkout simulation (removed `next-env.d.ts`, no prior `next dev`/`next build`):
```
$ rm -f next-env.d.ts && npm run typecheck

> digital-home@1.0.0 pretypecheck
> node scripts/ensure-next-env.js


> digital-home@1.0.0 typecheck
> tsgo --noEmit

$ echo $?
0
```

```
$ rm -f next-env.d.ts && npm run check

> digital-home@1.0.0 check
> oxlint && npm run typecheck

(oxlint warnings shown here are the pre-existing ones tracked separately in #9 / PR #10 — unrelated to this fix)

> digital-home@1.0.0 pretypecheck
> node scripts/ensure-next-env.js

> digital-home@1.0.0 typecheck
> tsgo --noEmit

$ echo $?
0
```

`git status` after the change shows only `package.json` modified and `scripts/ensure-next-env.js` added — `next-env.d.ts` itself stays untracked/gitignored, exactly as before.

## Notes
- This branch was cut from `master` directly (not from the oxlint-fix branch in #10/PR #10), so the `check`/`lint` output above still shows the 4 pre-existing oxlint warnings — those are out of scope here and addressed in PR #10.
- Considered requiring `next/dist/lib/typescript/writeAppTypeDeclarations` directly at pretypecheck time instead of duplicating its output, but that path is an internal, undocumented Next.js module (no `exports` restriction in `next`'s `package.json`, but also no public API guarantee), so hand-writing the verified-matching content felt more stable across Next patch versions than depending on Next internals at pretypecheck time.


---
_Generated by [Claude Code](https://claude.ai/code/session_013sSbaMVMMWeSvj9L12Ummp)_