### PR TITLE
fix(seo): serve robots.txt and list every route in the sitemap

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from 'next';
+import { SITE_URL } from '@/data/feed-pages';
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: {
+			userAgent: '*',
+			allow: ['/', '/og'],
+			// Personal listening data, not content — no reason to crawl it.
+			disallow: ['/api/']
+		},
+		sitemap: `${SITE_URL}/sitemap.xml`,
+		host: SITE_URL
+	};
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,27 @@
 import { MetadataRoute } from 'next';
+import { feedPages, SITE_URL } from '@/data/feed-pages';
+
+// Routes that are public but deliberately absent from the RSS feed, so they
+// carry no publish date of their own.
+const unfeedPaths = ['/latex-template'];
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const links = [
-		{
-			url: 'https://www.einargudni.com/',
-			lastModified: new Date()
-		}
-	];
+	const feedEntries = feedPages.map((page) => ({
+		url: `${SITE_URL}${page.path}`,
+		lastModified: new Date(page.date)
+	}));
 
-	return links;
+	const newestDate = feedPages.reduce(
+		(newest, page) => (page.date > newest ? page.date : newest),
+		feedPages[0].date
+	);
+
+	return [
+		{ url: `${SITE_URL}/`, lastModified: new Date(newestDate) },
+		...feedEntries,
+		...unfeedPaths.map((path) => ({
+			url: `${SITE_URL}${path}`,
+			lastModified: new Date(newestDate)
+		}))
+	];
 }

--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,0 @@
-Allow: /api/og/*


### PR DESCRIPTION
Crawlers currently can't enumerate this site. Two independent bugs, both silent.

## The sitemap listed one URL

`app/sitemap.ts` returned only `https://www.einargudni.com/` — the other nine routes were never advertised.

It now derives from `data/feed-pages.ts`, which already declares itself the source of truth for the RSS feed. Adding a page there now populates the feed **and** the sitemap from one edit, instead of a second hardcoded list that drifts. `/latex-template` has no feed entry, so it's handled via an explicit `unfeedPaths` list rather than being silently dropped.

`lastModified` now uses each page's real publish date. It previously used `new Date()`, which told crawlers every page changed on every deploy.

## robots.txt was never served

The file sat at the repo root instead of `public/`, so it returned 404. Nothing errors in this situation — it just looks correct in the repo forever.

Replaced with an `app/robots.ts` route handler so it can import `SITE_URL` and emit a `Sitemap:` directive that can't drift from the sitemap it points at. Deliberately did **not** also add `public/robots.txt` — a static file there would shadow the route.

Its only rule was `Allow: /api/og/*`, a path that doesn't exist; the OG endpoint is `/og` (`app/og/route.tsx`), so the rule was allowing nothing. Corrected. `/api/` is now disallowed, since those endpoints return Spotify listening data rather than content.

## Verification

- `bun run check` (oxlint + tsgo) clean — the 5 remaining warnings are pre-existing in untouched files
- Fetched both routes against `next dev`: `/robots.txt` serves with the `Sitemap:` directive, `/sitemap.xml` emits all 10 URLs with correct per-page dates

Worth confirming both on the Vercel preview, since static route generation can differ from dev. Note the preview will show production URLs — `SITE_URL` is hardcoded, which is correct for prod and expected on a preview.

## Not included

Also found during the audit, left for separate PRs: no `llms.txt`, no JSON-LD, metadata missing on ~7 of 10 routes, no `metadataBase`/canonical, and `app/feed.xml/route.ts` serving `application/atom+xml` while emitting RSS 2.0.

Separately confirmed `www` is canonical — the apex 307-redirects to it — so `layout.tsx` and `resume-data.tsx` are the files using the wrong host, not `sitemap.ts`.