### PR TITLE
feat: ship API errors to the life-os log hub

### DIFF
--- a/app/api/spotify/me/current/route.ts
+++ b/app/api/spotify/me/current/route.ts
@@ -2,12 +2,26 @@ import { currentlyPlayingSong } from '../../lib';
 import { type Song } from '../../types';
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
+import { logToHub } from '@/utils/hub-log';
 
 export async function GET(request: NextRequest) {
 	const f = 'current.GET';
 	console.log({ f });
 	const url = request.url;
-	const response = await currentlyPlayingSong(request);
+	let response: Response;
+	try {
+		response = await currentlyPlayingSong(request);
+	} catch (err) {
+		await logToHub({
+			level: 'error',
+			event: 'api.error',
+			fields: {
+				route: '/api/spotify/me/current',
+				message: err instanceof Error ? err.message : String(err)
+			}
+		});
+		throw err;
+	}
 
 	// Here we handle the request from the API
 	if (response.status === 204) {

--- a/app/api/spotify/me/recent/route.ts
+++ b/app/api/spotify/me/recent/route.ts
@@ -2,13 +2,27 @@ import { revalidatePath } from 'next/cache';
 import { lastPlayedSong } from '../../lib';
 import { Tracks, Track } from '../../types';
 import { NextRequest, NextResponse } from 'next/server';
+import { logToHub } from '@/utils/hub-log';
 
 export async function GET(request: NextRequest) {
 	const f = 'recent.GET';
 	console.log({ f });
 	const url = request.url;
 
-	const response = await lastPlayedSong(request);
+	let response: Response;
+	try {
+		response = await lastPlayedSong(request);
+	} catch (err) {
+		await logToHub({
+			level: 'error',
+			event: 'api.error',
+			fields: {
+				route: '/api/spotify/me/recent',
+				message: err instanceof Error ? err.message : String(err)
+			}
+		});
+		throw err;
+	}
 
 	// Here we handle the request from the API
 	if (response.status === 204) {

--- a/app/og/route.tsx
+++ b/app/og/route.tsx
@@ -1,6 +1,7 @@
 // import { ImageResponse } from 'next/server';
 import { ImageResponse } from 'next/og';
 import { NextRequest } from 'next/server';
+import { logToHub } from '@/utils/hub-log';
 
 export const runtime = 'edge';
 
@@ -10,7 +11,20 @@ export async function GET(req: NextRequest) {
 	const font = fetch(new URL('../../public/fonts/kaisei-tokumin-bold.ttf', import.meta.url)).then(
 		(res) => res.arrayBuffer()
 	);
-	const fontData = await font;
+	let fontData: ArrayBuffer;
+	try {
+		fontData = await font;
+	} catch (err) {
+		await logToHub({
+			level: 'error',
+			event: 'api.error',
+			fields: {
+				route: '/og',
+				message: err instanceof Error ? err.message : String(err)
+			}
+		});
+		throw err;
+	}
 
 	return new ImageResponse(
 		(

--- a/utils/hub-log.ts
+++ b/utils/hub-log.ts
@@ -1,0 +1,29 @@
+// Ship structured events to the life-os log hub (POST /v1/logs). SERVER-SIDE ONLY —
+// reads LIFEOS_INGEST_TOKEN, which must NEVER reach the browser. Best-effort: never
+// throws, and no-ops when the token is unset (e.g. local dev / preview without the env).
+const HUB_URL = process.env.LIFEOS_HUB_URL ?? 'https://einars-macbook-pro.tail5588b1.ts.net'
+const TOKEN = process.env.LIFEOS_INGEST_TOKEN
+const PROJECT = 'einargudni.com'
+
+type Level = 'info' | 'warn' | 'error'
+export interface HubEvent {
+  event: string
+  level?: Level
+  ts?: number
+  fields?: Record<string, unknown>
+}
+
+export const logToHub = async (events: HubEvent | HubEvent[]): Promise<void> => {
+  if (!TOKEN) return
+  const list = (Array.isArray(events) ? events : [events]).map((e) => ({ level: 'info' as Level, ts: Date.now(), ...e }))
+  try {
+    await fetch(`${HUB_URL}/v1/logs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ project: PROJECT, events: list }),
+      signal: AbortSignal.timeout(3000),
+    })
+  } catch {
+    // swallow — logging must never break the app
+  }
+}


### PR DESCRIPTION
Adds a server-only hub-log client (`utils/hub-log.ts`) and logs API-route errors to the life-os log hub via HTTP.

## What
- New `logToHub()` helper that POSTs structured events to the life-os log hub (`/v1/logs`). Server-side only: it reads `LIFEOS_INGEST_TOKEN` (never exposed to the browser) and is best-effort — it never throws and no-ops when the token is unset.
- Wired error logging into the API route handlers that call external services / can fail:
  - `app/api/spotify/me/current/route.ts` — wraps the `currentlyPlayingSong` (Spotify API) call, logs `api.error`, rethrows.
  - `app/api/spotify/me/recent/route.ts` — wraps the `lastPlayedSong` (Spotify API) call, logs `api.error`, rethrows.
  - `app/og/route.tsx` — wraps the external font fetch, logs `api.error`, rethrows.

## Config
Requires `LIFEOS_INGEST_TOKEN` in Vercel env to actually send. Without it the client no-ops (local dev / preview stay silent). `LIFEOS_HUB_URL` optionally overrides the default hub URL.

## Notes
Next.js 14.2 does not support the `onRequestError` instrumentation hook (Next 15+), so there is no single global server-error hook. Logging is therefore wired per-route into the existing handler error paths. `app/feed.xml/route.ts` was left untouched — it makes no external calls.

Behavior is unchanged: success responses and error status codes are identical; the added try/catch only logs then rethrows.